### PR TITLE
Sort posts descending by date + show date

### DIFF
--- a/templates/section.html
+++ b/templates/section.html
@@ -16,12 +16,19 @@
                     Posts
                 </div>
                 <ul>
-                    {% for page in section.pages %}
+                    {% for page in section.pages | sort(attribute="date") | reverse %}
                         <li class="text-slate-900 hover:text-slate-600
                             dark:text-slate-400 hover:dark:text-slate-300
                             transition">
                             <a class="flex my-12 lg:my-4 text-4xl lg:text-base" href="{{ page.permalink | safe }}">
-                                {{ page.title }}
+                                <div class="flex flex-col lg:flex-row lg:items-center" style="gap: 0.25rem;">
+                                    <span>{{ page.title }}</span>
+                                    {% if page.date %}
+                                        <span class="text-2xl lg:text-sm text-slate-500 dark:text-slate-600 mt-3 lg:mt-0 lg:ml-2">
+                                            {{ page.date | date(format="%Y-%m-%d") }}
+                                        </span>
+                                    {% endif %}
+                                </div>
                                 <div class="ml-2 hidden lg:inline">
                                     <i class="las la-arrow-right"></i>
                                 </div>


### PR DESCRIPTION
Blog entries were in random order with no date. This PR introduces dates on the list view and sorts it descending (latest first)

<img width="2001" height="1747" alt="Screenshot 2025-08-07 092800" src="https://github.com/user-attachments/assets/c297cee9-bc26-4f51-a464-25ba4376025f" />
<img width="2002" height="1740" alt="Screenshot 2025-08-07 092806" src="https://github.com/user-attachments/assets/00cfb24c-44e7-4f94-a6e3-648c67f8ac81" />
